### PR TITLE
GH-112: Cleaned up package.json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,20 @@ This project will involve the creation of a small collection of high-quality, re
 
 # Getting started
 
+To run the demos included in this package, check out the code and run the following commands.
+
 ```
-bower install
 npm install
-grunt build
 grunt demo
 ```
+Then open the demo server in your browser of choice:
 
 http://localhost:8001/
 
 #Demo
+
+The demos are also available online, you can find them at:
+
 http://dinukadesilva.github.io/music-ctrls/demo/knob.html
 
 http://dinukadesilva.github.io/music-ctrls/demo/piano.html

--- a/package.json
+++ b/package.json
@@ -1,27 +1,28 @@
 {
   "name": "sisiliano",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
+  "description": "This project provides a small collection of high-quality, responsive, SVG or DOM-based musical user interface controls.",
   "scripts": {
+    "postinstall": "bower install && grunt build",
     "test": "grunt build test"
   },
   "author": "Dinuka De Silba",
   "license": "ISC",
+  "repository": "https://github.com/dinukadesilva/music-ctrls/",
   "devDependencies": {
-    "grunt": "^0.4.5",
-    "grunt-cli": "^1.0.1",
-    "grunt-contrib-clean": "^1.0.0",
-    "grunt-contrib-concat": "^1.0.1",
-    "grunt-contrib-connect": "^1.0.0",
-    "grunt-contrib-copy": "^1.0.0",
-    "grunt-contrib-handlebars": "^1.0.0",
-    "grunt-contrib-jshint": "^1.0.0",
-    "grunt-contrib-less": "^1.2.0",
-    "grunt-contrib-qunit": "^1.2.0",
-    "grunt-contrib-uglify": "^1.0.1",
-    "grunt-contrib-watch": "^1.0.0",
+    "grunt": "1.0.1",
+    "grunt-cli": "1.0.1",
+    "grunt-contrib-clean": "1.0.0",
+    "grunt-contrib-concat": "1.0.1",
+    "grunt-contrib-connect": "1.0.0",
+    "grunt-contrib-copy": "1.0.0",
+    "grunt-contrib-handlebars": "1.0.0",
+    "grunt-contrib-jshint": "1.0.0",
+    "grunt-contrib-less": "1.2.0",
+    "grunt-contrib-qunit": "1.2.0",
+    "grunt-contrib-uglify": "2.0.0",
+    "grunt-contrib-watch": "1.0.0",
     "grunt-html2json": "git://github.com/Dinuka2013513/grunt-html2json.git",
-    "grunt-json": "^0.2.0"
+    "grunt-json": "0.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,13 +3,14 @@
   "version": "1.0.0",
   "description": "This project provides a small collection of high-quality, responsive, SVG or DOM-based musical user interface controls.",
   "scripts": {
-    "postinstall": "bower install && grunt build",
+    "postinstall": "node node_modules/bower/bin/bower install && grunt build",
     "test": "grunt build test"
   },
   "author": "Dinuka De Silba",
   "license": "ISC",
   "repository": "https://github.com/dinukadesilva/music-ctrls/",
   "dependencies": {
+    "bower": "1.7.9",
     "grunt": "1.0.1",
     "grunt-cli": "1.0.1",
     "grunt-contrib-clean": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Dinuka De Silba",
   "license": "ISC",
   "repository": "https://github.com/dinukadesilva/music-ctrls/",
-  "devDependencies": {
+  "dependencies": {
     "grunt": "1.0.1",
     "grunt-cli": "1.0.1",
     "grunt-contrib-clean": "1.0.0",
@@ -19,10 +19,12 @@
     "grunt-contrib-handlebars": "1.0.0",
     "grunt-contrib-jshint": "1.0.0",
     "grunt-contrib-less": "1.2.0",
-    "grunt-contrib-qunit": "1.2.0",
     "grunt-contrib-uglify": "2.0.0",
     "grunt-contrib-watch": "1.0.0",
     "grunt-html2json": "git://github.com/Dinuka2013513/grunt-html2json.git",
     "grunt-json": "0.2.0"
+  },
+  "devDependencies": {
+    "grunt-contrib-qunit": "1.2.0"
   }
 }


### PR DESCRIPTION
When installing this package as a dependency, the build task is not run, so you don't have a bundled script to include elsewhere. I fixed this by adding a "postinstall" script.  I also added a call to "bower install" to the same script, so that the tests and demos can now be run with less overall commands.

Finally, I cleaned up the package.json in general:
1. I pinned all dependencies to the latest available version rather than specifying a starting version.
2. I added a repository link.
3. I removed the inaccurate boilerplate "main" entry.
4. I paraphrased a section of the README for the "description field".

I also updated the README to reflect the reduced number of steps to run the demo.